### PR TITLE
Add script to extract BERT vectors for each token

### DIFF
--- a/extract_features.py
+++ b/extract_features.py
@@ -428,7 +428,7 @@ def main(_):
 
     # Write features to dictionary
     output_features["sentence_to_index"] = sentence_to_index
-    output_features[unique_id_str] = all_features
+    output_features[unique_id_str] = np.array(all_features).transpose((1, 0, 2))
 
   # Write dictionary to disk
   with open(FLAGS.output_file, "w") as fout:

--- a/extract_features.py
+++ b/extract_features.py
@@ -408,7 +408,7 @@ def main(_):
       for (i, token) in enumerate(feature.tokens):
         # only write token embedding if it corresponds to the representation
         # for an original word.
-        if i not in unique_id_to_feature[unique_id]["original_to_bert"]:
+        if i not in unique_id_to_token_info[unique_id]["original_to_bert"]:
           break
         all_layers = []
         for (j, layer_index) in enumerate(layer_indexes):

--- a/extract_features.py
+++ b/extract_features.py
@@ -424,9 +424,9 @@ def main(_):
         features["token"] = token
         features["layers"] = all_layers
         all_features.append(features)
+      output_json["features"] = all_features
       assert len(output_json["features"]) == len(
         output_json["token_info"]["original_to_bert"])
-      output_json["features"] = all_features
       writer.write(json.dumps(output_json) + "\n")
 
 

--- a/extract_features.py
+++ b/extract_features.py
@@ -77,6 +77,7 @@ flags.DEFINE_bool(
     "tf.nn.embedding_lookup will be used. On TPUs, this should be True "
     "since it is much faster.")
 
+NUM_BERT_LAYERS = 0
 
 class InputExample(object):
 
@@ -188,9 +189,9 @@ def model_fn_builder(bert_config, init_checkpoint, use_tpu,
         "unique_id": unique_ids,
     }
 
-    global num_bert_layers
-    num_bert_layers = len(all_layers)
-    for layer_index in range(num_bert_layers):
+    global NUM_BERT_LAYERS
+    NUM_BERT_LAYERS = len(all_layers)
+    for layer_index in range(NUM_BERT_LAYERS):
       predictions["layer_output_%d" % layer_index] = all_layers[layer_index]
 
     output_spec = tf.contrib.tpu.TPUEstimatorSpec(
@@ -382,7 +383,7 @@ def main(_):
       init_checkpoint=FLAGS.init_checkpoint,
       use_tpu=FLAGS.use_tpu,
       use_one_hot_embeddings=FLAGS.use_one_hot_embeddings)
-  print("number of bert layers: {}".format(num_bert_layers + 1))
+  print("number of bert layers: {}".format(NUM_BERT_LAYERS + 1))
 
   # If TPU is not available, this will fall back to normal Estimator on CPU
   # or GPU.
@@ -415,7 +416,7 @@ def main(_):
         continue
       # Len: num_layers
       all_layers = []
-      for layer_num in enumerate(num_bert_layers):
+      for layer_num in enumerate(NUM_BERT_LAYERS):
         layer_output = result["layer_output_%d" % layer_num]
         layer_output_values = [
             round(float(x), 6) for x in layer_output[i:(i + 1)].flat

--- a/extract_features.py
+++ b/extract_features.py
@@ -27,6 +27,7 @@ import tensorflow as tf
 
 import h5py
 import numpy as np
+from tqdm import tqdm
 
 flags = tf.flags
 
@@ -398,7 +399,7 @@ def main(_):
   output_features = {}
   sentence_to_index = {}
   with h5py.File(FLAGS.output_file, "w") as fout:
-    for result in estimator.predict(input_fn, yield_single_examples=True):
+    for result in tqdm(estimator.predict(input_fn, yield_single_examples=True)):
       unique_id = int(result["unique_id"])
       unique_id_str = str(unique_id)
       sentence_to_index[

--- a/extract_features.py
+++ b/extract_features.py
@@ -426,6 +426,14 @@ def main(_):
 
       # Write features to HDF5
       features_to_write = np.array(all_features).transpose((1, 0, 2))
+      # Check that number of timesteps in features is the same as
+      # the number of words.
+      if len(unique_id_to_token_info[unique_id]["original_tokens"]) != features_to_write.shape[1]:
+        raise ValueError("Original tokens: {} with len {}. "
+                         "Shape of features_to_write: {}".format(
+                           unique_id_to_token_info[unique_id]["original_tokens"],
+                           len(unique_id_to_token_info[unique_id]["original_tokens"]),
+                           features_to_write.shape))
       fout.create_dataset(unique_id_str,
                           features_to_write.shape, dtype='float32',
                           data=features_to_write)

--- a/extract_features.py
+++ b/extract_features.py
@@ -364,6 +364,7 @@ def main(_):
       original_to_bert.append(len(bert_tokens))
       bert_tokens.extend(tokenizer.tokenize(orig_token))
     bert_tokens.append("[SEP]")
+    assert len(original_to_bert) == len(original_tokens)
     unique_id_to_token_info[example.unique_id] = {
       "original_tokens": original_tokens,
       "bert_tokens": bert_tokens,
@@ -423,6 +424,8 @@ def main(_):
         features["token"] = token
         features["layers"] = all_layers
         all_features.append(features)
+      assert len(output_json["features"]) == len(
+        output_json["token_info"]["original_to_bert"])
       output_json["features"] = all_features
       writer.write(json.dumps(output_json) + "\n")
 

--- a/extract_features.py
+++ b/extract_features.py
@@ -184,6 +184,8 @@ def model_fn_builder(bert_config, init_checkpoint, use_tpu,
       tf.train.init_from_checkpoint(init_checkpoint, assignment_map)
 
     all_layers = model.get_all_encoder_layers()
+    # Prepend the embeddings to all_layers
+    all_layers.insert(0, model.get_embedding_output())
 
     predictions = {
         "unique_id": unique_ids,

--- a/extract_features.py
+++ b/extract_features.py
@@ -27,6 +27,8 @@ import modeling
 import tokenization
 import tensorflow as tf
 
+import numpy as np
+
 flags = tf.flags
 
 FLAGS = flags.FLAGS

--- a/extract_features.py
+++ b/extract_features.py
@@ -416,7 +416,7 @@ def main(_):
         continue
       # Len: num_layers
       all_layers = []
-      for layer_num in enumerate(NUM_BERT_LAYERS):
+      for layer_num in range(NUM_BERT_LAYERS):
         layer_output = result["layer_output_%d" % layer_num]
         layer_output_values = [
             round(float(x), 6) for x in layer_output[i:(i + 1)].flat

--- a/extract_features.py
+++ b/extract_features.py
@@ -383,7 +383,6 @@ def main(_):
       init_checkpoint=FLAGS.init_checkpoint,
       use_tpu=FLAGS.use_tpu,
       use_one_hot_embeddings=FLAGS.use_one_hot_embeddings)
-  print("number of bert layers: {}".format(NUM_BERT_LAYERS + 1))
 
   # If TPU is not available, this will fall back to normal Estimator on CPU
   # or GPU.

--- a/extract_features.py
+++ b/extract_features.py
@@ -409,7 +409,7 @@ def main(_):
         # only write token embedding if it corresponds to the representation
         # for an original word.
         if i not in unique_id_to_token_info[unique_id]["original_to_bert"]:
-          break
+          continue
         all_layers = []
         for (j, layer_index) in enumerate(layer_indexes):
           layer_output = result["layer_output_%d" % j]

--- a/extract_features.py
+++ b/extract_features.py
@@ -419,12 +419,10 @@ def main(_):
       all_layers = []
       for (j, layer_index) in enumerate(layer_indexes):
         layer_output = result["layer_output_%d" % j]
-        layers = collections.OrderedDict()
-        layers["index"] = layer_index
-        layers["values"] = [
+        layer_output_values = [
             round(float(x), 6) for x in layer_output[i:(i + 1)].flat
         ]
-        all_layers.append(layers)
+        all_layers.append(layer_output_values)
       all_layers = np.array(all_layers)
       all_features.append(all_layers)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 tensorflow >= 1.11.0   # CPU Version of TensorFlow.
 # tensorflow-gpu  >= 1.11.0  # GPU version of TensorFlow.
+numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ tensorflow >= 1.11.0   # CPU Version of TensorFlow.
 # tensorflow-gpu  >= 1.11.0  # GPU version of TensorFlow.
 numpy
 h5py
+tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 tensorflow >= 1.11.0   # CPU Version of TensorFlow.
 # tensorflow-gpu  >= 1.11.0  # GPU version of TensorFlow.
 numpy
+h5py


### PR DESCRIPTION
- dumps output in the same format as ELMo
- dumps all the layers, including the character-level embeddings
- dumps only vectors corresponding to word tokens, not byte pairs (as in the original script)
- example usage (for running the BERT base, cased model):

```
python ${BERT_EXTRACT_FEATURES_PATH} --input_file=input_text.txt \
           --output_file=output_path.hdf5 \
           --vocab_file=cased_L-12_H-768_A-12/vocab.txt \
           --bert_config_file=cased_L-12_H-768_A-12/bert_config.json \
           --init_checkpoint=cased_L-12_H-768_A-12/bert_model.ckpt \
           --max_seq_length=384 \
           --batch_size=8 \
           --do_lower_case=false
```